### PR TITLE
adding escape characters in grep for better filtering!

### DIFF
--- a/arsenal/resolver.sh
+++ b/arsenal/resolver.sh
@@ -7,4 +7,4 @@ subfinder -d $1 > $dir/$1_subd;
 assetfinder --subs-only $1 >> $dir/$1_subd;
 chaos -d $1 -key 072644535d0624cfbc08fdf200a50794c95bd2b0f09906fc278d137e5964a376 -silent >> $dir/$1_subd;
 cat $dir/$1_subd | sort -u > $dir/$1_subdomains;
-cat $dir/$1_subdomains | httpx -follow-redirects -status-code -vhost -threads 300 -silent | sort -u | grep "[200]" | cut -d [ -f1 | uniq >> $dir/$1_resolved
+cat $dir/$1_subdomains | httpx -follow-redirects -status-code -vhost -threads 300 -silent | sort -u | grep "\[200\]" | cut -d [ -f1 | uniq >> $dir/$1_resolved


### PR DESCRIPTION
Hi,
I'm not sure why you are just taking 200 status codes domains! 403,404 does matter in some cases!
Nevertheless, if you still want to grab only 200's I have made a change in grep command! Earlier it was also throwing 403,404 codes because "[]" was not escaped!
I have added escape character so this will now only save 200's domain in $dir/$1_resolved.
Hope that helps!
Take care,
shubham