### PR TITLE
added custom header to nuclei scan

### DIFF
--- a/arsenal/nuclear.sh
+++ b/arsenal/nuclear.sh
@@ -2,5 +2,5 @@
 
 dir=~/Recon/$1
 
-cat $dir/$1_probed | ~/go/bin/nuclei -c 500 -silent -t ~/Tools/nuclei-templates/ -o $dir/$1_nuclei;
+cat $dir/$1_probed | ~/go/bin/nuclei -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0" -c 500 -silent -t ~/Tools/nuclei-templates/ -o $dir/$1_nuclei;
 


### PR DESCRIPTION
Hi,
Sometimes websites block and/or gives different results if we run nuclei without a proper header!
the default header that goes with every request is (Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

it's good to have a custom header rather than a default one to bypass protections at some level.
Hope that helps!
Best,
Shubham