### PR TITLE
Patch 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ A few features like port scanning might not be working in the current build and 
 
 ``targetfile`` contains list of domains to perform Recon. For example: `targettest.com`
 
+### Exclude out-of-scope subdomains
+
+Bheem has a flag to remove out-of-scope subdomains from the scan. To do so you have to use "-e" flag with comma separated subdomains.
+
+``Bheem -t targetfile -S -e sub.ex.com,sub1.ex.com``
+
 # Side Notes
 
 1. If you don't want to use specific module, just comment it out and it won't be used anymore.

--- a/arsenal/Bheem.sh
+++ b/arsenal/Bheem.sh
@@ -60,9 +60,11 @@ large_recon(){
 
 }
 
-while getopts ":t:SMLh" opt; do
+while getopts ":t:eSMLh" opt; do
 	case ${opt} in
 		t ) target=$OPTARG
+		    ;;
+		e ) exclude=$OPTARG
 		    ;;
 		S ) small_recon
 		    ;;
@@ -72,6 +74,7 @@ while getopts ":t:SMLh" opt; do
 		    ;;
 		\? | h ) echo "Usage  :";
 			 echo "         -t	List of target";
+			 echo "		-e	Exclude target.(eg: sub1.ex.com,sub2.ex.com)";
 			 echo "         -S	Perform Small Recon";
 			 echo "         -M	Perform Medium Recon";
 			 echo "         -L	Perform Large Recon";

--- a/arsenal/subdomain.sh
+++ b/arsenal/subdomain.sh
@@ -6,5 +6,14 @@ mkdir -p $dir
 ~/go/bin/subfinder -d $1 > $dir/$1_unfilter_subdomains;
 ~/go/bin/assetfinder --subs-only $1 >> $dir/$1_unfilter_subdomains;
 #amass enum -d $1 >> $dir/$1_unfilter_subdomains;
-cat $dir/$1_unfilter_subdomains | sort -u > $dir/$1_subdomains;
 
+if [ -z "$exclude" ]
+then
+  cat $dir/$1_unfilter_subdomains | sort -u > $dir/$1_subdomains;
+else
+  echo -e "\e[92m[~] Excluding domains..\e[00m"
+  echo "${exclude[*]}" | cut -d',' --output-delimiter=$'\n' -f1- | tee -a $dir/"$1"_excluded.txt
+  cat $dir/"$1"_unfilter_subdomains | sort -u | grep "\.$1" > $dir/tmp_Bunique.txt
+  grep -vFf $dir/"$1"_excluded.txt $dir/tmp_Bunique.txt > $dir/$1_subdomains
+  rm $dir/tmp_Bunique.txt
+fi


### PR DESCRIPTION
Hi,
I have added an option to exclude out-of-scope subdomains from the scan.

Users can give out-of-scope subdomains using the flag "-e". with comma-separated values.

It's always a good choice to skip out-of-scope domains during an automated scan! especially heavy traffic scans such as directory Bruteforce, portscan!

I hope this will help!

Thanks :)