### PR TITLE
Update jscan.sh

### DIFF
--- a/arsenal/jscan.sh
+++ b/arsenal/jscan.sh
@@ -7,7 +7,7 @@ echo $1 | hakrawler -js -depth 2 -scope subs -plain >> $dir/$1_jsfile_links;
 
 cat $dir/$1_jsfile_links | httpx -follow-redirects -silent -status-code | grep "[200]" | cut -d ' ' -f1 | sort -u > $dir/$1_live_jsfile_links;
 
-python3 ~/Tools/LinkFinder/linkfinder.py -d -i $1 -o cli >> $dir/$1_JSEndpoints;
+python3 ~/Tools/LinkFinder/linkfinder.py -d -i https://$1 -o cli >> $dir/$1_JSEndpoints;
 
 cat $dir/$1_live_jsfile_links | python3 ~/Tools/getjswords.py | sort -u > $dir/$1_JSWords;
 


### PR DESCRIPTION
Link finder doesn't provide result when -i is example.com . Add https protocol ex: https://example.com