### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ sudo apt-get install python3;
 sudo apt-get install python3-pip;
 sudo apt-get install ruby;
 sudo apt-get install screen;
+sudo apt-get install libpcap-dev;
 sudo apt-get install git;
 mkdir ~/.gf
 mkdir ~/Tools;


### PR DESCRIPTION
Naabu by pd requires 'libpcap' library to install properly. Its not installed by default in kali linux. So, it fails to install naabu with the install.sh script.